### PR TITLE
[PLAT-406] chore: upgraded macOS resource_class to macos.m1.medium.gen1

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -17,6 +17,7 @@ executors:
   macos:
     macos:
       xcode: 14.0.0
+    resource_class: 'macos.m1.medium.gen1'
   integration-test:
     docker:
       - image: cimg/node:current


### PR DESCRIPTION
upgraded CircleCI macos resource class to `macos.m1.medium.gen1`

see: [Passed CI on M1 Medium](https://app.circleci.com/pipelines/github/autifyhq/autify-circleci-orb-mobile/476/workflows/42ed41ee-b013-416c-94d4-2954c04dbe7b/jobs/6132)